### PR TITLE
adding authenticated helper

### DIFF
--- a/base-ui/org.wso2.carbon.uuf.ui.feature/src/main/resources/jaggeryapps/uuf-app/lib/constants.js
+++ b/base-ui/org.wso2.carbon.uuf.ui.feature/src/main/resources/jaggeryapps/uuf-app/lib/constants.js
@@ -59,5 +59,10 @@ var constants = {
     HELPER_PARAM_UNIT_PARAMS: "_unitParams",
     HELPER_PARAM_OVERRIDE: "override",
     HELPER_PARAM_COMBINE: "combine",
-    HELPER_PARAM_SCOPE: "scope"
+    HELPER_PARAM_SCOPE: "scope",
+    //authentication
+    USER_SESSION_KEY: "userSessionKey",
+    DEFAULT_USER_SESSION_KEY: "USER",
+    LOGIN_REDIRECTION_URI_KEY: "loginRedirectionUri",
+    DEFAULT_LOGIN_REDIRECTION_URI: "/login"
 };

--- a/base-ui/org.wso2.carbon.uuf.ui.feature/src/main/resources/jaggeryapps/uuf-app/lib/rendering-handlebars-helpers.js
+++ b/base-ui/org.wso2.carbon.uuf.ui.feature/src/main/resources/jaggeryapps/uuf-app/lib/rendering-handlebars-helpers.js
@@ -532,6 +532,33 @@ function registerHelpers(renderingData, lookupTable) {
     }
 
     /**
+     * 'authenticated' Handlebars helper function.
+     * @returns {string} empty string
+     */
+    function authenticationHelper(){
+        var appConf = Utils.getAppConfigurations();
+        //retrieving user session key
+        var userSessionKey = appConf[constants.USER_SESSION_KEY];
+        if(!userSessionKey){
+            userSessionKey = constants.DEFAULT_USER_SESSION_KEY;
+        }
+        var loggedUser = session.get(userSessionKey);
+
+        //check user already logged in
+        if(loggedUser == null){
+            //retrieving loging redirection uri
+            var loginRedirectionUri = appConf[constants.LOGIN_REDIRECTION_URI_KEY];
+            if(!loginRedirectionUri){
+                loginRedirectionUri = constants.DEFAULT_LOGIN_REDIRECTION_URI;
+            }
+            //dispatch redirection to login uri
+            response.sendRedirect(renderingData.context.appData.uri + loginRedirectionUri);
+            exit();
+        }
+        return "";
+    }
+
+    /**
      * 'defineZone' Handlebars helper function.
      * @param zoneName {string}
      * @param options {Object}
@@ -671,6 +698,9 @@ function registerHelpers(renderingData, lookupTable) {
         },
         js: function (path, options) {
             return resourceHelper("js", path, options)
+        },
+        authenticated: function () {
+            return authenticationHelper()
         },
         defineZone: defineZoneHelper
     });


### PR DESCRIPTION
UUF App developers will be able redirect the user into a login page with just a {{authenticated}} handlebar helper.

How to use:
1. In app/conf/app-conf.json; user can mention;
"userSessionKey" : "MY_USER_VAR", // <-- jaggery session key for the user variable
"loginRedirectionUri" : "/signin", // <-- login redirection page when user session not found or invalidated

*If the above configurations are not present; following default values will be applied;
"userSessionKey" : "USER",
"loginRedirectionUri" : "/login"
1. Add {{authenticated}} on relevant page unit "hbs" file.
